### PR TITLE
docs: dedupe gh-delivery docs

### DIFF
--- a/implementation/lsd-delivery.md
+++ b/implementation/lsd-delivery.md
@@ -35,6 +35,14 @@ nav_order: 90
 
 不要在各仓库复制脚本/流程文档；统一以组织仓库 `lawseekdog/.github` 提供的 team skill 为准：
 
+前置（每台机器一次，确保 AI 可自动维护 Projects）：  
+
+```bash
+gh auth login
+gh auth refresh -s project,read:org,repo,workflow
+gh auth status
+```
+
 - 安装：`npx -y skills add lawseekdog/.github@lsd-delivery -g -y`
 - 验证：`~/.agents/skills/lsd-delivery/scripts/lsd-work doctor`
 - 完整可用命令：`~/.agents/skills/lsd-delivery/scripts/lsd-work --help`
@@ -89,3 +97,17 @@ gh issue develop <num> --checkout
 - 项目：LawSeekDog Delivery（Projects v2 #1）
 - 规则与字段以看板 Readme 为准（Status / Agent / Work Type / Priority / Target Repo / Epic 等）
 
+## 6) Skills 更新（每台机器）
+
+- 检查更新：`npx -y skills check -g`
+- 更新全部全局 skills：`npx -y skills update -g`
+- 只更新 lsd-delivery：`npx -y skills add lawseekdog/.github@lsd-delivery -g -y`
+- 更新后建议跑一次：`~/.agents/skills/lsd-delivery/scripts/lsd-work doctor`
+
+## 7) 配置（可选）
+
+环境变量（均为可选，默认值见括号）：
+
+- `LSD_PROJECT_OWNER`（`lawseekdog`）
+- `LSD_PROJECT_NUMBER`（`1`）
+- `LSD_AGENT_DEFAULT`（`Codex`）

--- a/tools/gh-delivery/README.md
+++ b/tools/gh-delivery/README.md
@@ -1,38 +1,16 @@
-# gh-delivery
+# gh-delivery (deprecated)
 
-Deprecated location for the LawSeekDog multi-repo delivery workflow helper.
+This directory keeps a tiny wrapper for backwards compatibility:
 
-**Source of truth** lives in the org repo `lawseekdog/.github` as the `lsd-delivery` skill.
+- Wrapper: `./tools/gh-delivery/lsd-work` (delegates to the installed skill)
 
-This folder keeps a tiny wrapper (`./tools/gh-delivery/lsd-work`) for backwards compatibility,
-but it delegates to the installed skill script.
+Single source of truth:
 
-## Prereqs
+- Docs: `/implementation/lsd-delivery.md`
+- Tool: org repo `lawseekdog/.github` skill `lsd-delivery` (`~/.agents/skills/lsd-delivery/scripts/lsd-work`)
 
-- GitHub CLI (`gh`)
-- Token scopes include `project`:
-
-```bash
-gh auth refresh -s project,read:org,repo,workflow
-gh auth status
-```
-
-## Quick start
+Example:
 
 ```bash
-npx -y skills add lawseekdog/.github@lsd-delivery -g -y
-~/.agents/skills/lsd-delivery/scripts/lsd-work bootstrap
-~/.agents/skills/lsd-delivery/scripts/lsd-work doctor
+./tools/gh-delivery/lsd-work doctor
 ```
-
-Docs:
-
-- See `/implementation/lsd-delivery.md` in this docs site.
-
-## Config
-
-Environment variables:
-
-- `LSD_PROJECT_OWNER` (default: `lawseekdog`)
-- `LSD_PROJECT_NUMBER` (default: `1`)
-- `LSD_AGENT_DEFAULT` (default: `Codex`)


### PR DESCRIPTION
## Summary
Dedupe `tools/gh-delivery` docs so this workflow has a single source of truth.

## Agent
- Agent: Codex

## Related Issue
Closes #8

## Changes
- Simplify `tools/gh-delivery/README.md` to pointer-only (keep wrapper script).
- Add prereqs + skill update commands + optional env var config to `implementation/lsd-delivery.md`.

## Why
Avoid duplicated workflow docs and reduce drift.

## Scope Guard
- Allowed scope reference: https://github.com/lawseekdog/docs/issues/8
- Out of scope verified: docs-only change

## How to Test
1. Read the updated docs pages and confirm links/commands.

## Verification
- [ ] `echo ok`

## Context References
-

## Checklist
- [x] Issue is linked with closing keyword (e.g. `Closes #123`)
- [x] All touched files are within the Issues Allowed Scope
- [x] No Out of Scope paths/files were modified
- [ ] Tests pass (see Verification)
- [x] PR is appropriately scoped (not too large)
- [x] Self-reviewed (read diff as if someone else wrote it)
